### PR TITLE
Update Storybook addon metadata

### DIFF
--- a/rtl/package.json
+++ b/rtl/package.json
@@ -22,7 +22,9 @@
     "rtl",
     "i18n",
     "bidirection",
-    "pxblue"
+    "pxblue",
+    "storybook-addon",
+    "style"
   ],
   "author": "PX Blue <pxblue@eaton.com>",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Hey pxblue! We've created a catalog of Storybook addons and yours is included: https://storybook.js.org/addons/@pxblue/storybook-rtl-addon

To make your addon more discoverable in the catalog, we've curated some of its metadata, and I've included those edits in this PR.

To learn more about the catalog metadata, check out our documentation: https://storybook.js.org/docs/react/addons/addon-catalog
